### PR TITLE
Use MM.getFrame in easey.run

### DIFF
--- a/src/easey.js
+++ b/src/easey.js
@@ -129,12 +129,6 @@
             return futures;
         };
 
-        var fastFrame = function(callback) {
-            window.setTimeout(function () {
-                callback(+new Date());
-            }, 1);
-        };
-
         easey.run = function(time, callback) {
 
             var start = (+new Date());
@@ -153,7 +147,7 @@
                 } else {
                     map.coordinate = path(from, to, easings.easeIn(delta / time));
                     map.draw();
-                    fastFrame(tick);
+                    MM.getFrame(tick);
                 }
             }
 


### PR DESCRIPTION
I'm not very familiar with native animation frames, so there might be a good reason for fastFrame() which I'm missing. Is there any reason why MM.getFrame wasn't being used?
